### PR TITLE
Allow calling script to explicitly set what command to run

### DIFF
--- a/containit.sh
+++ b/containit.sh
@@ -103,7 +103,7 @@ DOCKER_IMAGE="${IMAGE:-alpine:latest}"
 # The command to execute in the container is the command "name" we were called
 # with. The intended use is for soft links to point to this file with names
 # like "npm". That would execute npm inside the container.
-EXEC_CMD="$(basename "$0")"
+EXEC_CMD="${EXEC_CMD:-$(basename "$0")}"
 
 BIN_DIR="$(realPath "$(dirname "$0")")"
 PROJECT_ROOT="$(realPath "${BIN_DIR}/..")"


### PR DESCRIPTION
EXEC_CMD is the executable that containit will run, previously always
pulled from $0. With this change, the user of containit.sh can explicitly
set EXEC_CMD to the command that will be executed and it will not get
overwritten.

This allows the name of the user-executed script to be different than the actual executable run in the container.